### PR TITLE
Update gaseous-signature-parser to version 2.4.1

### DIFF
--- a/hasheous-client/hasheous-client.csproj
+++ b/hasheous-client/hasheous-client.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="gaseous-signature-parser" Version="2.4.0" />
+    <PackageReference Include="gaseous-signature-parser" Version="2.4.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="gaseous.IGDB" Version="1.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
Upgrade the gaseous-signature-parser package to the latest version for improved functionality and performance.