### PR TITLE
Bump package versions for dependencies

### DIFF
--- a/hasheous-client/hasheous-client.csproj
+++ b/hasheous-client/hasheous-client.csproj
@@ -33,11 +33,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="gaseous-signature-parser" Version="2.4.8" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="all" />
+    <PackageReference Include="gaseous-signature-parser" Version="2.5.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="all" />
     <PackageReference Include="gaseous.IGDB" Version="1.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="System.Text.Json" Version="10.0.3" />
+    <PackageReference Include="System.Text.Json" Version="10.0.5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Update versions for gaseous-signature-parser, Microsoft.SourceLink.GitHub, and System.Text.Json to their latest releases.