### PR TITLE
Support multiple hash lookups

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/TestApp/bin/Debug/net8.0/TestApp.dll",
+            "program": "${workspaceFolder}/TestApp/bin/Debug/net10.0/TestApp.dll",
             "cwd": "${workspaceFolder}/TestApp",
             "stopAtEntry": false,
             "projectPath": "${workspaceFolder}/TestApp/TestApp.csproj",

--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -1,17 +1,25 @@
 ﻿// See https://aka.ms/new-console-template for more information
 using HasheousClient.Models;
 
-HasheousClient.WebApp.HttpHelper.BaseUri = "https://beta.hasheous.org/";
+HasheousClient.WebApp.HttpHelper.BaseUri = "https://localhost:7157/";
 HasheousClient.WebApp.HttpHelper.APIKey = "";
 HasheousClient.WebApp.HttpHelper.ClientKey = "rMnTbIjaCYtfDfCMX3Mes55rgBdrbUMfP2jgW_Nz2nYQdQ8EgHVZR0zfyvbd957x";
 
 HasheousClient.Hasheous hasheous = new HasheousClient.Hasheous();
 
 Console.WriteLine("Fetching data from Hasheous...");
-LookupItemModel? HasheousResult = hasheous.RetrieveFromHasheous(new HashLookupModel
+List<HashLookupModel> hashLookupModels = new List<HashLookupModel>
 {
-    MD5 = "cff69b70a8ad674a0efe5558765855c9"
-}, "TOSEC, MAMEArcade, MAMEMess, NoIntros, Redump, WHDLoad, RetroAchievements, FBNeo");
+    new HashLookupModel
+    {
+        CRC = "cb214447"
+    },
+    new HashLookupModel
+    {
+        CRC = "d1852012"
+    }
+};
+LookupItemModel? HasheousResult = hasheous.RetrieveFromHasheous(hashLookupModels, "TOSEC, MAMEArcade, MAMEMess, NoIntros, Redump, WHDLoad, RetroAchievements, FBNeo");
 
 if (HasheousResult != null)
 {
@@ -25,24 +33,24 @@ if (HasheousResult != null)
     Console.WriteLine(outString);
 }
 
-Console.WriteLine("Fetching platforms from Hasheous...");
-List<DataObjectItem> platforms = hasheous.GetPlatforms();
-for (int i = 0; i < platforms.Count; i++)
-{
-    Console.WriteLine(i + ": " + platforms[i].Name);
-}
+// Console.WriteLine("Fetching platforms from Hasheous...");
+// List<DataObjectItem> platforms = hasheous.GetPlatforms();
+// for (int i = 0; i < platforms.Count; i++)
+// {
+//     Console.WriteLine(i + ": " + platforms[i].Name);
+// }
 
-Console.WriteLine("Fetching metadata via metadata proxy from Hasheous...");
-HasheousClient.Models.Metadata.IGDB.Game metadataProxy = hasheous.GetMetadataProxy<HasheousClient.Models.Metadata.IGDB.Game>(HasheousClient.Models.MetadataSources.IGDB, 3192);
-if (metadataProxy != null)
-{
-    Newtonsoft.Json.JsonSerializerSettings jsonSerializerSettings = new Newtonsoft.Json.JsonSerializerSettings
-    {
-        Formatting = Newtonsoft.Json.Formatting.Indented,
-        NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore,
-        MaxDepth = 8
-    };
-    jsonSerializerSettings.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter());
-    string outString = Newtonsoft.Json.JsonConvert.SerializeObject(metadataProxy, jsonSerializerSettings);
-    Console.WriteLine(outString);
-}
+// Console.WriteLine("Fetching metadata via metadata proxy from Hasheous...");
+// HasheousClient.Models.Metadata.IGDB.Game metadataProxy = hasheous.GetMetadataProxy<HasheousClient.Models.Metadata.IGDB.Game>(HasheousClient.Models.MetadataSources.IGDB, 3192);
+// if (metadataProxy != null)
+// {
+//     Newtonsoft.Json.JsonSerializerSettings jsonSerializerSettings = new Newtonsoft.Json.JsonSerializerSettings
+//     {
+//         Formatting = Newtonsoft.Json.Formatting.Indented,
+//         NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore,
+//         MaxDepth = 8
+//     };
+//     jsonSerializerSettings.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter());
+//     string outString = Newtonsoft.Json.JsonConvert.SerializeObject(metadataProxy, jsonSerializerSettings);
+//     Console.WriteLine(outString);
+// }

--- a/hasheous-client/Classes/HasheousClient.cs
+++ b/hasheous-client/Classes/HasheousClient.cs
@@ -21,7 +21,7 @@ namespace HasheousClient
         /// <returns>
         /// The lookup item
         /// </returns>
-        public LookupItemModel RetrieveFromHasheous(HashLookupModel hash, bool returnAllSources)
+        public LookupItemModel RetrieveFromHasheous(List<HashLookupModel> hash, bool returnAllSources)
         {
             Task<LookupItemModel> result = _RetrieveFromHasheousAsync(hash, returnAllSources);
 
@@ -40,7 +40,7 @@ namespace HasheousClient
         /// <returns>
         /// The lookup item
         /// </returns>
-        public LookupItemModel RetrieveFromHasheous(HashLookupModel hash, string sourceList)
+        public LookupItemModel RetrieveFromHasheous(List<HashLookupModel> hash, string sourceList)
         {
             Task<LookupItemModel> result = _RetrieveFromHasheousAsync(hash, sourceList);
 
@@ -56,7 +56,7 @@ namespace HasheousClient
         /// <returns>
         /// The lookup item
         /// </returns>
-        public async Task<LookupItemModel> RetrieveFromHasheousAsync(HashLookupModel hash, bool returnAllSources)
+        public async Task<LookupItemModel> RetrieveFromHasheousAsync(List<HashLookupModel> hash, bool returnAllSources)
         {
             return await _RetrieveFromHasheousAsync(hash, returnAllSources);
         }
@@ -73,7 +73,7 @@ namespace HasheousClient
         /// <returns>
         /// The lookup item
         /// </returns>
-        public async Task<LookupItemModel> RetrieveFromHasheousAsync(HashLookupModel hash, string sourceList)
+        public async Task<LookupItemModel> RetrieveFromHasheousAsync(List<HashLookupModel> hash, string sourceList)
         {
             return await _RetrieveFromHasheousAsync(hash, sourceList);
         }
@@ -601,7 +601,7 @@ namespace HasheousClient
             return result;
         }
 
-        private static async Task<LookupItemModel> _RetrieveFromHasheousAsync(HashLookupModel hashLookup, bool returnAllSources)
+        private static async Task<LookupItemModel> _RetrieveFromHasheousAsync(List<HashLookupModel> hashLookup, bool returnAllSources)
         {
             string sourceList = "returnAllSources=" + returnAllSources.ToString();
             if (returnAllSources)
@@ -624,7 +624,7 @@ namespace HasheousClient
             return result;
         }
 
-        private static async Task<LookupItemModel> _RetrieveFromHasheousAsync(HashLookupModel hashLookup, string sourceList)
+        private static async Task<LookupItemModel> _RetrieveFromHasheousAsync(List<HashLookupModel> hashLookup, string sourceList)
         {
             var result = await HasheousClient.WebApp.HttpHelper.Post<LookupItemModel>($"/api/v1/Lookup/ByHash?{sourceList}", hashLookup);
 

--- a/hasheous-client/Classes/HasheousClient.cs
+++ b/hasheous-client/Classes/HasheousClient.cs
@@ -12,11 +12,84 @@ namespace HasheousClient
         // disables warning about methods should be static as these methods may require instance state in the future
         // and we want to remain backwards compatible
 
+        #region Single Hash
         /// <summary>
         /// Retrieve a lookup item from Hasheous
         /// </summary>
         /// <param name="hash">
         /// The hash to lookup
+        /// </param>
+        /// <returns>
+        /// The lookup item
+        /// </returns>
+        public LookupItemModel RetrieveFromHasheous(HashLookupModel hash, bool returnAllSources)
+        {
+            List<HashLookupModel> hashLookup = new List<HashLookupModel> { hash };
+            Task<LookupItemModel> result = _RetrieveFromHasheousAsync(hashLookup, returnAllSources);
+
+            return result.Result;
+        }
+
+        /// <summary>
+        /// Retrieve a lookup item from Hasheous
+        /// </summary>
+        /// <param name="hash">
+        /// The hash to lookup
+        /// </param>
+        /// <param name="sourceList">
+        /// The comma separated list of sources to return
+        /// </param>
+        /// <returns>
+        /// The lookup item
+        /// </returns>
+        public LookupItemModel RetrieveFromHasheous(HashLookupModel hash, string sourceList)
+        {
+            List<HashLookupModel> hashLookup = new List<HashLookupModel> { hash };
+            Task<LookupItemModel> result = _RetrieveFromHasheousAsync(hashLookup, sourceList);
+
+            return result.Result;
+        }
+
+        /// <summary>
+        /// Retrieve a lookup item from Hasheous
+        /// </summary>
+        /// <param name="hash">
+        /// The hash to lookup
+        /// </param>
+        /// <returns>
+        /// The lookup item
+        /// </returns>
+        public async Task<LookupItemModel> RetrieveFromHasheousAsync(HashLookupModel hash, bool returnAllSources)
+        {
+            List<HashLookupModel> hashLookup = new List<HashLookupModel> { hash };
+            return await _RetrieveFromHasheousAsync(hashLookup, returnAllSources);
+        }
+
+        /// <summary>
+        /// Retrieve a lookup item from Hasheous
+        /// </summary>
+        /// <param name="hash">
+        /// The hash to lookup
+        /// </param>
+        /// <param name="sourceList">
+        /// The comma separated list of sources to return
+        /// </param>
+        /// <returns>
+        /// The lookup item
+        /// </returns>
+        public async Task<LookupItemModel> RetrieveFromHasheousAsync(HashLookupModel hash, string sourceList)
+        {
+            List<HashLookupModel> hashLookup = new List<HashLookupModel> { hash };
+            return await _RetrieveFromHasheousAsync(hashLookup, sourceList);
+        }
+        #endregion Single Hash
+
+        #region Hash Arrays
+        /// <summary>
+        /// Retrieve a lookup item from Hasheous
+        /// </summary>
+        /// <param name="hash">
+        /// The list of hashes to lookup
         /// </param>
         /// <returns>
         /// The lookup item
@@ -32,7 +105,7 @@ namespace HasheousClient
         /// Retrieve a lookup item from Hasheous
         /// </summary>
         /// <param name="hash">
-        /// The hash to lookup
+        /// The list of hashes to lookup
         /// </param>
         /// <param name="sourceList">
         /// The comma separated list of sources to return
@@ -51,7 +124,7 @@ namespace HasheousClient
         /// Retrieve a lookup item from Hasheous
         /// </summary>
         /// <param name="hash">
-        /// The hash to lookup
+        /// The list of hashes to lookup
         /// </param>
         /// <returns>
         /// The lookup item
@@ -65,7 +138,7 @@ namespace HasheousClient
         /// Retrieve a lookup item from Hasheous
         /// </summary>
         /// <param name="hash">
-        /// The hash to lookup
+        /// The list of hashes to lookup
         /// </param>
         /// <param name="sourceList">
         /// The comma separated list of sources to return
@@ -77,6 +150,7 @@ namespace HasheousClient
         {
             return await _RetrieveFromHasheousAsync(hash, sourceList);
         }
+        #endregion Hash Arrays
 
         /// <summary>
         /// Fix a match in Hasheous


### PR DESCRIPTION
Update the `RetrieveFromHasheous` method to accept a list of `HashLookupModel`, enabling the retrieval of multiple hashes in a single request.