### PR TITLE
Bump gaseous.IGDB to 1.0.6 and add ArtworkType model

### DIFF
--- a/TestApp/TestApp.csproj
+++ b/TestApp/TestApp.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="gaseous.IGDB" Version="1.0.5" />
+    <PackageReference Include="gaseous.IGDB" Version="1.0.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 </Project>

--- a/hasheous-client/Models/Metadata/IGDB/Artwork.cs
+++ b/hasheous-client/Models/Metadata/IGDB/Artwork.cs
@@ -15,6 +15,10 @@ namespace HasheousClient.Models.Metadata.IGDB
         [JsonProperty("animated")]
         public bool? Animated { get; set; }
 
+        [JsonPropertyName("artwork_type")]
+        [JsonProperty("artwork_type")]
+        public long ArtworkType { get; set; }
+
         [JsonPropertyName("checksum")]
         [JsonProperty("checksum")]
         public string Checksum { get; set; }

--- a/hasheous-client/Models/Metadata/IGDB/ArtworkType.cs
+++ b/hasheous-client/Models/Metadata/IGDB/ArtworkType.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace HasheousClient.Models.Metadata.IGDB
 {
-    public class ArtworkType : ITools, IHasChecksum
+    public class ArtworkType : ITools, IIdentifier, IHasChecksum
     {
         [JsonPropertyName("checksum")]
         [JsonProperty("checksum")]

--- a/hasheous-client/Models/Metadata/IGDB/ArtworkType.cs
+++ b/hasheous-client/Models/Metadata/IGDB/ArtworkType.cs
@@ -14,6 +14,10 @@ namespace HasheousClient.Models.Metadata.IGDB
         [JsonProperty("created_at")]
         public DateTimeOffset? CreatedAt { get; set; }
 
+        [JsonPropertyName("id")]
+        [JsonProperty("id")]
+        public long? Id { get; set; }
+
         [JsonPropertyName("name")]
         [JsonProperty("name")]
         public string Name { get; set; }

--- a/hasheous-client/Models/Metadata/IGDB/ArtworkType.cs
+++ b/hasheous-client/Models/Metadata/IGDB/ArtworkType.cs
@@ -1,0 +1,29 @@
+using Newtonsoft.Json;
+
+using System.Text.Json.Serialization;
+
+namespace HasheousClient.Models.Metadata.IGDB
+{
+    public class ArtworkType : ITools, IHasChecksum
+    {
+        [JsonPropertyName("checksum")]
+        [JsonProperty("checksum")]
+        public string Checksum { get; set; }
+
+        [JsonPropertyName("created_at")]
+        [JsonProperty("created_at")]
+        public DateTimeOffset? CreatedAt { get; set; }
+
+        [JsonPropertyName("name")]
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("slug")]
+        [JsonProperty("slug")]
+        public string Slug { get; set; }
+
+        [JsonPropertyName("updated_at")]
+        [JsonProperty("updated_at")]
+        public DateTimeOffset? UpdatedAt { get; set; }
+    }
+}

--- a/hasheous-client/hasheous-client.csproj
+++ b/hasheous-client/hasheous-client.csproj
@@ -35,7 +35,7 @@
   <ItemGroup>
     <PackageReference Include="gaseous-signature-parser" Version="2.7.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="all" />
-    <PackageReference Include="gaseous.IGDB" Version="1.0.5" />
+    <PackageReference Include="gaseous.IGDB" Version="1.0.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Text.Json" Version="10.0.9" />
   </ItemGroup>


### PR DESCRIPTION
Update the gaseous.IGDB package to version 1.0.6 and introduce a new ArtworkType model to handle additional IGDB metadata properties. This enhances the application's ability to manage artwork-related data.